### PR TITLE
fetchData Allow customize filter parameters.

### DIFF
--- a/stream_table.js
+++ b/stream_table.js
@@ -300,7 +300,12 @@
   };
 
   _F.fetchData = function(){
-    var _self = this, params = {q: this.last_search_text}
+    var _self = this, 
+        params = this.opts.params || {};
+    
+    if (!params['q']) {
+      params['q'] = this.last_search_text;
+    }
 
     if (this.opts.fetch_data_limit) {
       params['limit'] = this.opts.fetch_data_limit;


### PR DESCRIPTION
Most of the time when a table loads would be good if we can pass some other params to be send on the request to the server, adding this capability, also the query param should not be force set on the fetch data if it is passed.