### PR TITLE
Preventing the last unnecessary paging request to the server

### DIFF
--- a/stream_table.js
+++ b/stream_table.js
@@ -315,7 +315,7 @@
     $.getJSON(this.opts.data_url, params).done(function(data){
       data = _self.addData(data);
 
-      if (params.limit != null && (!data || !data.length ) ) {
+      if (params.limit != null && (!data || !data.length || data.length < params.limit) ) {
         _self.stopStreaming();
       }else{
         _self.setStreamInterval();


### PR DESCRIPTION
Since the last response has less items than limit, it should be the last page. We don't need to check for an empty response.