### PR TITLE
Disable rendering the same content

### DIFF
--- a/stream_table.js
+++ b/stream_table.js
@@ -271,7 +271,10 @@
     data = this.execCallbacks('before_add', data) || data;
 
     if (data.length){
-      var i = this.data.length, l = data.length + i;
+      var i = this.data.length, l = data.length + i, render = false;
+
+      if (this.data.length < this.opts.fetch_data_limit)
+        render = true;
 
       this.buildTextIndex(data);
       this.data = this.data.concat(data);
@@ -290,7 +293,9 @@
         this.sort(this.current_sorting);
       }
 
-      this.render(this.current_page);
+      if (render)
+        this.render(this.current_page);
+
       this.renderPagination(this.pageCount(), this.current_page);
       this.execCallbacks('after_add', data);
       this.execCallbacks('pagination');


### PR DESCRIPTION
I was having issues with the https://github.com/vitalets/x-editable, the editable popup won't remain open because stream table was replacing the page content with every subsequent ajax request.